### PR TITLE
Separately link GLU on newer MacOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -129,7 +129,11 @@ deps = [
 
 # OpenGL, specifically the GLU library
 deps += [dependency('gl')]
-if os.startswith('linux')
+if os == 'darwin'
+  # newer MacOS splits out GLU into a separate framework, but we can't
+  # ask Meson for the version in order to handle things differently
+  deps += [dependency('glu', required: false)]
+elif os.startswith('linux')
   deps += [dependency('glu')]
 elif os == 'windows'
   deps += [cpp.find_library('glu32')]


### PR DESCRIPTION
Fix based on @BenHocking's bug report last Friday.

This should really be in a conditional based on MacOS version, but
Meson's `target_machine` API doesn't currently surface that. Making
the dependency optional instead means it'll try and fail on older
versions before moving on.