### PR TITLE
tasks handle repeat configuration messages.

### DIFF
--- a/src/Tasks/TaskServiceBase.cpp
+++ b/src/Tasks/TaskServiceBase.cpp
@@ -114,7 +114,11 @@ bool TaskServiceBase::configure(const pugi::xml_node& serviceXmlNode)
                 m_entityConfigurations.insert(std::make_pair(entityConfiguration->getID(), entityConfiguration));
                 auto nominalSpeedToOneDecimalPlace_mps = std::round(entityConfiguration->getNominalSpeed()*10.0) / 10.0;
                 auto nominalAltitudeRounded = std::round(entityConfiguration->getNominalAltitude());
-                m_speedAltitudeVsEligibleEntityIds[std::make_pair(nominalSpeedToOneDecimalPlace_mps, nominalAltitudeRounded)].push_back(entityConfiguration->getID());
+                auto targetEntityIds = m_speedAltitudeVsEligibleEntityIds[std::make_pair(nominalSpeedToOneDecimalPlace_mps, nominalAltitudeRounded)];
+                if (std::find(targetEntityIds.begin(), targetEntityIds.end(), entityConfiguration->getID()) == targetEntityIds.end())
+                {
+                    m_speedAltitudeVsEligibleEntityIds[std::make_pair(nominalSpeedToOneDecimalPlace_mps, nominalAltitudeRounded)].push_back(entityConfiguration->getID());
+                }
             }
         }
         else if ( dynamic_cast<afrl::cmasi::EntityState*>(object) )
@@ -269,7 +273,11 @@ bool TaskServiceBase::processReceivedLmcpMessage(std::unique_ptr<uxas::communica
             m_entityConfigurations.insert(std::make_pair(entityConfiguration->getID(), entityConfiguration));
             auto nominalSpeedToOneDecimalPlace_mps = std::round(entityConfiguration->getNominalSpeed()*10.0) / 10.0;
             auto nominalAltitudeRounded = std::round(entityConfiguration->getNominalAltitude());
-            m_speedAltitudeVsEligibleEntityIds[std::make_pair(nominalSpeedToOneDecimalPlace_mps, nominalAltitudeRounded)].push_back(entityConfiguration->getID());
+            auto targetEntityIds = m_speedAltitudeVsEligibleEntityIds[std::make_pair(nominalSpeedToOneDecimalPlace_mps, nominalAltitudeRounded)];
+            if (std::find(targetEntityIds.begin(), targetEntityIds.end(), entityConfiguration->getID()) == targetEntityIds.end())
+            {
+                m_speedAltitudeVsEligibleEntityIds[std::make_pair(nominalSpeedToOneDecimalPlace_mps, nominalAltitudeRounded)].push_back(entityConfiguration->getID());
+            }
         }
     }
     else if (uxas::messages::task::isUniqueAutomationRequest(receivedLmcpMessage->m_object))


### PR DESCRIPTION
if a configuration message is sent after a task has been initialized, then m_speedAltitudeVsEligibleEntityIds will have the id of the entity appended. The appending will always happen, allowing the same entity to be inserted multiple times. This is then used to calculate task options incorrectly or redundantly.

Another approach would be to use a set instead of a vector. This was not done because it would touch many tasks, some of which use the first element, which a set does not have.

The changes under the configure method are redundant because the configs there are guaranteed to be distinct since they come from the TaskManager. These changes are for completeness. 

