### PR TITLE
Bring back the gtest wrap

### DIFF
--- a/3rd/.gitignore
+++ b/3rd/.gitignore
@@ -1,29 +1,29 @@
-# downloaded 3rd party libraries
-*.tar
-boost_1_64_0
-cppzmq-4.2.2
-czmq-4.0.2
-googletest-release-1.8.0
-minizip-1.2
-packagecache
-#serial-1.2.1
-sqlite-amalgamation-3120200
-SQLiteCpp-1.3.1
-zeromq-4.2.3
-zlib-1.2.8
-zyre-2.0.0
-
 !wrap_patches
 
+# downloaded 3rd party libraries
+*.tar
+/boost_1_64_0
+/cppzmq-4.2.2
+/czmq-4.0.2
+/googletest-release-1.8.0
+/minizip-1.2
+/packagecache
+#serial-1.2.1
+/sqlite-amalgamation-3120200
+/SQLiteCpp-1.3.1
+/zeromq-4.2.3
+/zlib-1.2.8
+/zyre-2.0.0
+
 # generated .wrap files from .wrap.tmpl
-boost.wrap
-cppzmq.wrap
-czmq.wrap
-gtest.wrap
-minizip.wrap
-serial.wrap
-sqlite3.wrap
-sqlitecpp.wrap
-zeromq.wrap
-zlib.wrap
-zyre.wrap
+/boost.wrap
+/cppzmq.wrap
+/czmq.wrap
+/gtest.wrap
+/minizip.wrap
+/serial.wrap
+/sqlite3.wrap
+/sqlitecpp.wrap
+/zeromq.wrap
+/zlib.wrap
+/zyre.wrap

--- a/3rd/gtest.wrap.tmpl
+++ b/3rd/gtest.wrap.tmpl
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = googletest-release-1.8.0
+
+source_url = https://github.com/google/googletest/archive/release-1.8.0.zip
+source_filename = gtest-1.8.0.zip
+source_hash = f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf
+
+patch_url = %top%/googletest-release-1.8.0_patch.tar
+patch_filename = googletest-release-1.8.0_patch.tar
+patch_hash = %patch_hash%

--- a/3rd/wrap_patches/googletest-release-1.8.0/googletest/meson.build
+++ b/3rd/wrap_patches/googletest-release-1.8.0/googletest/meson.build
@@ -1,0 +1,15 @@
+incdir = include_directories('include', '.')
+libsources = files('src/gtest-all.cc')
+mainsources = files('src/gtest_main.cc')
+
+lib = static_library(
+  'gtest',
+  libsources,
+  dependencies: dependency('threads'),
+  include_directories: incdir,
+)
+
+dep = declare_dependency(
+  link_with: lib,
+  include_directories: incdir,
+)

--- a/3rd/wrap_patches/googletest-release-1.8.0/meson.build
+++ b/3rd/wrap_patches/googletest-release-1.8.0/meson.build
@@ -1,0 +1,3 @@
+project('gtest', 'cpp', version : '1.8.0', license : 'bsd')
+
+subdir('googletest')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,7 @@
-dep_gtest = dependency('gtest')
+dep_gtest = dependency(
+  'gtest',
+  fallback: ['gtest', 'dep']
+)
 
 deps_test = deps + [
   dep_gtest


### PR DESCRIPTION
Meson is supposed to have built-in magic about the gtest dependency, but it doesn't seem to work consistently.