### PR TITLE
Rework Travis for native Linux and Mac builds

### DIFF
--- a/.Brewfile
+++ b/.Brewfile
@@ -1,0 +1,2 @@
+brew "python3"
+brew "ant"

--- a/.Brewfile
+++ b/.Brewfile
@@ -1,2 +1,3 @@
 brew "python3"
 brew "ant"
+brew "ninja"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,60 @@
-sudo: required
+dist: trusty
+sudo: false
 
-services:
-  - docker
+os:
+  - linux
+  - osx
+
+language:
+  - cpp
+
+addons:
+  apt:
+    packages:
+      - libglu1-mesa-dev
+      - uuid-dev
+      - libboost-date-time-dev
+      - libboost-filesystem-dev
+      - libboost-regex-dev
+      - libboost-system-dev
+      - libgtest-dev
+      - ant
+      - oracle-java8-set-default
+
+before_install:
+  # Homebrew deps for Mac
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew bundle --file=./.Brewfile; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export BOOST_ROOT=/usr/local; fi
+  - mkdir -p ~/.local/bin
+  - export PATH=~/.local/bin:$PATH
+  # install verion of Meson that is compatible with UxAS build
+  - curl -L -s https://github.com/mesonbuild/meson/archive/0.44.0.zip -o meson.zip
+  - unzip meson.zip
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=~/Library/Python/3.6/bin:$PATH; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd meson-0.44.0; python3 setup.py install; cd ..; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd meson-0.44.0; python3 setup.py install --user; cd ..; fi
+  - meson --version
+  # download newer Ninja than is packaged in repos
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -L -s https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-mac.zip -o ninja.zip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl -L -s https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip -o ninja.zip; fi
+  - unzip ninja.zip
+  - mv ninja ~/.local/bin
+  - ninja --version
 
 install:
-  # clone LmcpGen
+  # clone, build, and run LmcpGen
   - git clone https://github.com/afrl-rq/LmcpGen.git ../LmcpGen
   # tries to check out the same branch as the one we're building if it's
   # available, so that development can proceed in tandem
   # - (cd ../LmcpGen; (git checkout $TRAVIS_BRANCH || true); ant jar)
+  - cd ../LmcpGen; ant jar; cd ../OpenUxAS
+  - sh RunLmcpGen.sh
+  # process the wraps and their patches
+  - ./prepare
+
+before_script:
+  - meson build
 
 script:
-  - (cd docker/develop; ./01_buildImage_UxAS_build.sh && ./02_buildUxAS_WithDocker.sh && ./03_stopAndRemoveBuildContainer.sh && ./04_runUxAS_Tests.sh)
-  - (cd docker/deploy; ./01_buildRun_Image.sh)
+  # build with -j2; Travis has 2 "cores"
+  - ninja -C build test -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,60 +1,34 @@
 dist: trusty
-sudo: false
 
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - services: docker
+      os: linux
+      env: BUILD_FLAVOR=linux_docker
+      sudo: required
+    - os: linux
+      env: BUILD_FLAVOR=linux_native
+      sudo: false
+      addons:
+        apt:
+          sources:
+            - deadsnakes
+          packages:
+            - libglu1-mesa-dev
+            - uuid-dev
+            - libboost-date-time-dev
+            - libboost-filesystem-dev
+            - libboost-regex-dev
+            - libboost-system-dev
+            - libgtest-dev
+            - ant
+            - oracle-java8-set-default
+            - python3.6
+    - os: osx
+      env: BUILD_FLAVOR=osx_native
+      sudo: false
 
-language:
-  - cpp
-
-addons:
-  apt:
-    packages:
-      - libglu1-mesa-dev
-      - uuid-dev
-      - libboost-date-time-dev
-      - libboost-filesystem-dev
-      - libboost-regex-dev
-      - libboost-system-dev
-      - libgtest-dev
-      - ant
-      - oracle-java8-set-default
-
-before_install:
-  # Homebrew deps for Mac
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew bundle --file=./.Brewfile; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export BOOST_ROOT=/usr/local; fi
-  - mkdir -p ~/.local/bin
-  - export PATH=~/.local/bin:$PATH
-  # install verion of Meson that is compatible with UxAS build
-  - curl -L -s https://github.com/mesonbuild/meson/archive/0.44.0.zip -o meson.zip
-  - unzip meson.zip
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=~/Library/Python/3.6/bin:$PATH; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd meson-0.44.0; python3 setup.py install; cd ..; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd meson-0.44.0; python3 setup.py install --user; cd ..; fi
-  - meson --version
-  # download newer Ninja than is packaged in repos
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -L -s https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-mac.zip -o ninja.zip; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl -L -s https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip -o ninja.zip; fi
-  - unzip ninja.zip
-  - mv ninja ~/.local/bin
-  - ninja --version
-
-install:
-  # clone, build, and run LmcpGen
-  - git clone https://github.com/afrl-rq/LmcpGen.git ../LmcpGen
-  # tries to check out the same branch as the one we're building if it's
-  # available, so that development can proceed in tandem
-  # - (cd ../LmcpGen; (git checkout $TRAVIS_BRANCH || true); ant jar)
-  - cd ../LmcpGen; ant jar; cd ../OpenUxAS
-  - sh RunLmcpGen.sh
-  # process the wraps and their patches
-  - ./prepare
-
-before_script:
-  - meson build
+language: cpp
 
 script:
-  # build with -j2; Travis has 2 "cores"
-  - ninja -C build test -j2
+  - bash ci/travis.sh

--- a/3rd/wrap_patches/SQLiteCpp-1.3.1/meson.build
+++ b/3rd/wrap_patches/SQLiteCpp-1.3.1/meson.build
@@ -2,8 +2,15 @@ project('sqlitecpp', 'cpp')
 
 dep_sqlite3 = dependency(
   'sqlite3',
-  fallback: ['sqlite3', 'dep'],
+  required: false,
 )
+
+# force native build of SQLite3 if load extension function is unavailable
+cpp = meson.get_compiler('cpp')
+if not dep_sqlite3.found() or not cpp.has_function('sqlite3_enable_load_extension', dependencies: dep_sqlite3)
+  dep_sqlite3 = subproject('sqlite3').get_variable('dep')
+endif
+
 
 lib = static_library(
   'sqlitecpp',

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -1,0 +1,12 @@
+set -ev
+
+if [[ "$BUILD_FLAVOR" == "linux_docker" ]]; then
+    source ci/travis_docker.sh;
+elif [[ "$BUILD_FLAVOR" == "linux_native" ]]; then
+    source ci/travis_linux.sh;
+elif [[ "$BUILD_FLAVOR" == "osx_native" ]]; then
+    source ci/travis_osx.sh;
+else
+    echo "Error: unexpected Travis build flavor: $BUILD_FLAVOR";
+    false;
+fi

--- a/ci/travis_docker.sh
+++ b/ci/travis_docker.sh
@@ -1,0 +1,4 @@
+git clone https://github.com/afrl-rq/LmcpGen.git ../LmcpGen
+
+(pushd docker/develop; ./01_buildImage_UxAS_build.sh && ./02_buildUxAS_WithDocker.sh && ./03_stopAndRemoveBuildContainer.sh && ./04_runUxAS_Tests.sh; popd)
+(pushd docker/deploy; ./01_buildRun_Image.sh; popd)

--- a/ci/travis_linux.sh
+++ b/ci/travis_linux.sh
@@ -1,0 +1,28 @@
+mkdir -p ~/.local/bin
+export PATH=~/.local/bin:$PATH
+
+# install verion of Meson that is compatible with UxAS build
+curl -L -s https://github.com/mesonbuild/meson/archive/0.45.0.zip -o meson.zip
+unzip -q meson.zip
+pushd meson-0.45.0; python3.6 setup.py install --user; popd
+meson --version
+
+# download newer Ninja than is packaged in repos
+curl -L -s https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip -o ninja.zip
+unzip -q ninja.zip
+mv ninja ~/.local/bin
+ninja --version
+
+# clone, build, and run LmcpGen
+git clone https://github.com/afrl-rq/LmcpGen.git ../LmcpGen
+pushd ../LmcpGen; ant jar; popd
+sh RunLmcpGen.sh
+
+# process the wraps and their patches
+./prepare
+
+# build with -j2; Travis has 2 "cores"
+meson build
+ninja -C build -j2
+# run test suite with *2 timeout multiplier, because Travis can be slow
+meson test -C build -t 2

--- a/ci/travis_osx.sh
+++ b/ci/travis_osx.sh
@@ -1,0 +1,27 @@
+mkdir -p ~/.local/bin
+export PATH=~/.local/bin:$PATH
+
+# Homebrew deps for Mac
+brew bundle --file=./.Brewfile
+export BOOST_ROOT=/usr/local
+
+# install verion of Meson that is compatible with UxAS build
+curl -L -s https://github.com/mesonbuild/meson/archive/0.45.0.zip -o meson.zip
+unzip -q meson.zip
+export PATH=~/Library/Python/3.6/bin:$PATH
+pushd meson-0.45.0; python3 setup.py install; popd;
+meson --version
+
+# clone, build, and run LmcpGen
+git clone https://github.com/afrl-rq/LmcpGen.git ../LmcpGen
+pushd ../LmcpGen; ant jar; popd
+sh RunLmcpGen.sh
+
+# process the wraps and their patches
+./prepare
+
+# build with -j2; Travis has 2 "cores"
+meson build
+ninja -C build -j2
+# run test suite with *2 timeout multiplier, because Travis can be slow
+meson test -C build -t 2


### PR DESCRIPTION
Reverts the Docker-based Travis script in favor of one that does a native build on Linux and Mac. Windows still in progress