### PR TITLE
Fix minizip hash

### DIFF
--- a/3rd/minizip.wrap.tmpl
+++ b/3rd/minizip.wrap.tmpl
@@ -3,7 +3,7 @@
 directory = minizip-1.2
 source_url = https://github.com/nmoinvaz/minizip/archive/1.2.zip
 source_filename = 1.2.zip
-source_hash = e2d113da6e6c22ba0487e9a81a179195b9f41e182b1cf3e843acf53bce794b7c
+source_hash = dbae4d903a22a2ada22371e231949ee228b40ff53e271126513528dbc86d3679
 
 patch_url = %top%/minizip-1.2_patch.tar
 patch_filename = minizip-1.2_patch.tar


### PR DESCRIPTION
Their hash changed again.

This should also be updated in `develop`, as well as in release `v0.1.1` at least.