### PR TITLE
Fix format string vulnerability

### DIFF
--- a/src/Communications/ZeroMqZyreBridge.cpp
+++ b/src/Communications/ZeroMqZyreBridge.cpp
@@ -122,14 +122,14 @@ ZeroMqZyreBridge::start(const std::string& zyreNetworkDevice, const std::string&
     else
     {
         UXAS_LOG_INFORM_ASSIGNMENT(s_typeName(), "::start creating new Zyre node with node ID ", m_zyreNodeId, " zyre endpoint ", zyreEndpoint, " and gossip endpoint ", gossipEndpoint);
-        zyre_set_endpoint(m_zyreNode, m_zyreEndpoint.c_str());
+        zyre_set_endpoint(m_zyreNode, "%s", m_zyreEndpoint.c_str());
         if(m_isGossipBind)
         {
-            zyre_gossip_bind(m_zyreNode, m_gossipEndpoint.c_str());
+            zyre_gossip_bind(m_zyreNode, "%s", m_gossipEndpoint.c_str());
         }
         else
         {
-            zyre_gossip_connect(m_zyreNode, m_gossipEndpoint.c_str());
+            zyre_gossip_connect(m_zyreNode, "%s", m_gossipEndpoint.c_str());
         }
     }
 


### PR DESCRIPTION
The functions `zyre_set_endpoint`, `zyre_gossip_bind`, and `zyre_gossip_connect` take as second argument a format string.

While passing a computed string as an argument works, it is a cause for bugs (if the string happens to contain a `%` character), or worse, a security vulnerability.

Some compilers treat this as an error and will not compiler OpenUxAS as is.