### PR TITLE
Fixed java install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ The [install prerequisities script](https://raw.githubusercontent.com/afrl-rq/Op
    * `sudo apt install oracle-java9-set-default`
 1. Install `ant` for command line build of java programs: in terminal
    * `sudo apt install ant`
+1. Remove any previously installed versions of ZMQ - They're likely to cause compile errors which, if fixed, will leave you with a seg-fault.
 1. [Build](#build-uxas)
 
 ## Install Prerequisites on Mac OS X

--- a/install_prerequisites.sh
+++ b/install_prerequisites.sh
@@ -89,7 +89,7 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     # Install unique ID creation library: in terminal
     sudo apt -y install uuid-dev
     # Install Boost libraries (**optional but recommended**; see external dependencies section): in terminal
-    sudo apt-get install libboost-filesystem-dev libboost-regex-dev libboost-system-dev
+    sudo apt-get -y install libboost-filesystem-dev libboost-regex-dev libboost-system-dev
     # Install pip3: in terminal
     sudo apt -y install python3-pip
     sudo -H pip3 install --upgrade pip
@@ -101,11 +101,8 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     sudo apt -y install python3-tk
     sudo -H pip3 install matplotlib
     sudo -H pip3 install pandas
-    # Install Oracle JDK
-    sudo add-apt-repository ppa:webupd8team/java
-    sudo apt -y update
-    sudo apt -y install oracle-java9-installer
-    sudo apt -y install oracle-java9-set-default
+    # Install Java
+    sudo apt -y install openjdk-11-jdk
     # Install ant for command line build of java programs
     sudo apt -y install ant
     echo "Dependencies installed!"
@@ -129,28 +126,54 @@ if [ $current_directory == "OpenUxAS" ] && [ -d $git_directory ]; then
    cd ..
 fi
 
-echo "Checking out LmcpGen ..."
-git clone https://github.com/afrl-rq/LmcpGen.git
+if [ ! -d LmcpGen ]; then
+	echo "Checking out LmcpGen ..."
+	git clone https://github.com/afrl-rq/LmcpGen.git
+fi
 cd LmcpGen
 ant -q jar
 cd ..
-echo "Checking out OpenAMASE ..."
-git clone https://github.com/afrl-rq/OpenAMASE.git
+
+if [ ! -d OpenAMASE ]; then
+	echo "Checkout out OpenAMASE..."
+	git clone https://github.com/afrl-rq/OpenAMASE.git
+fi
 cd OpenAMASE/OpenAMASE
 ant -q jar
 cd ../..
-    
+  
 echo "Configuring UxAS plotting utilities ..."
 cd OpenUxAS/src/Utilities/localcoords
 sudo python3 setup.py install
 cd ../../..
 
 echo "Preparing UxAS build ..."
+rm -rf build_release build_debug
 python3 prepare
 sh RunLmcpGen.sh
-meson build --buildtype=release
+meson build_release --buildtype=release
 meson build_debug --buildtype=debug
 
-echo "Complete! To build, type 'ninja -C build'"
+echo "Performing initial UxAS build ..."
+ninja -C build_debug
+ninja -C build_release
+
+# Alias the debug build
+ln -s build_debug build
+
+cat <<'EOF'
+
+================================================================
+
+DONE!
+
+Subsequent builds are done using:
+
+  $ ninja -C build_debug
+
+and 
+
+  $ ninja -C build_release
+EOF
 
 # --eof--


### PR DESCRIPTION
Java 9 has been unavailable for a while, java 8 is also no longer available from the spot the script was trying to get it. If it's available elsewhere, I've not found it. At any rate, it's easy to get Java 11 which is what I pull below.

I also modified the script so it'd only clone the OpenAMASE and Lmcpgen repos if they weren't already present on the system.